### PR TITLE
Add rules for not allowing chained arrows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@getify/eslint-plugin-proper-arrows": "^8.0.1",
     "eslint-config-airbnb-base": "^14.0.0",
     "object.assign": "^4.1.0",
     "object.entries": "^1.1.0"

--- a/rules.yaml
+++ b/rules.yaml
@@ -2,6 +2,7 @@
 
 plugins:
   - import
+  - "@getify/proper-arrows"
 rules:
   semi: ["warn", "always"]
 
@@ -56,6 +57,10 @@ rules:
     - blankLine: always
       prev: ["*"]
       next: ["function", "export", "class"]
+
+  "@getify/proper-arrows/return":
+    - "warn"
+    - chained: true
 
 
   # TODO: Fix these, downgraded to warnings for now

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,11 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@getify/eslint-plugin-proper-arrows@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@getify/eslint-plugin-proper-arrows/-/eslint-plugin-proper-arrows-8.0.1.tgz#478ebf109d792f634a3449684328520161989366"
+  integrity sha512-S8VIdlc321iexhGa8BX55jHdlvJwW/9hTZawxidXoi8tecpi6k5tpOcExv3xXMPFuWrRu+hrS03mVRxkxHNeyw==
+
 acorn-jsx@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.2.tgz#84b68ea44b373c4f8686023a551f61a21b7c4a4f"
@@ -251,13 +256,6 @@ eslint-config-airbnb-base@^14.0.0:
   integrity sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==
   dependencies:
     confusing-browser-globals "^1.0.7"
-    object.assign "^4.1.0"
-    object.entries "^1.1.0"
-
-eslint-config-doc@../eslint-config-doc:
-  version "1.0.0"
-  dependencies:
-    eslint-config-doc "../eslint-config-doc"
     object.assign "^4.1.0"
     object.entries "^1.1.0"
 


### PR DESCRIPTION
```
const a = b => c => `${b}${c}`;
```
```
  1:16  warning  Chained arrow function return needs visual delimiters '(' and ')'  @getify/proper-arrows/return
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bluebikesolutions/eslint-config-dutyofcare/1)
<!-- Reviewable:end -->
