### PR TITLE
Allow await in loop

### DIFF
--- a/rules.yaml
+++ b/rules.yaml
@@ -13,6 +13,8 @@ rules:
 
   arrow-parens: ["error", "as-needed"]
 
+  no-await-in-loop: ["off"]
+  
   consistent-return:
     - "warn"
     - treatUndefinedAsUnspecified: true


### PR DESCRIPTION
Awaiting in a loop is generally bad if you are waiting for an already known list of things which could be parallel.

There are enough use cases for awaiting in loops that this isn't a 'lint' issue, it should be picked up in code review if there's an async problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bluebikesolutions/eslint-config-dutyofcare/2)
<!-- Reviewable:end -->
